### PR TITLE
Fixed procfile not specifying a web dyno

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+web: bin/rails server -p $PORT -e $RAILS_ENV
 release: bundle exec rake sof_setup:wait_db db:migrate db:seed


### PR DESCRIPTION
The procfile did not define a "web" section, so there was no dyno running on Heroku.