### PR TITLE
Added LetsEncrypt challenge endpoint

### DIFF
--- a/app/assets/javascripts/lets_encrypt.coffee
+++ b/app/assets/javascripts/lets_encrypt.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/lets_encrypt.scss
+++ b/app/assets/stylesheets/lets_encrypt.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the lets_encrypt controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/lets_encrypt_controller.rb
+++ b/app/controllers/lets_encrypt_controller.rb
@@ -1,0 +1,19 @@
+class LetsEncryptController < ApplicationController
+  def challenge
+    if params[:id] == key
+      render plain: challenge_hash
+    else
+      render nothing: true, status: 404
+    end
+  end
+
+  def key
+    unless challenge_hash.nil?
+      challenge_hash.split('.')[0]
+    end
+  end
+
+  def challenge_hash
+    ENV['LETSENCRYPT_CHALLENGE']
+  end
+end

--- a/app/helpers/lets_encrypt_helper.rb
+++ b/app/helpers/lets_encrypt_helper.rb
@@ -1,0 +1,2 @@
+module LetsEncryptHelper
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,7 @@ Rails.application.routes.draw do
   get 'index' => 'pages#index'
   get 'info' => 'pages#info'
   get 'contacts' => 'pages#contacts'
+
+  # Let’s encrypt
+  get '/.well-known/acme-challenge/:id' => 'lets_encrypt#challenge', as: :letsencrypt_challenge
 end

--- a/test/controllers/lets_encrypt_controller_test.rb
+++ b/test/controllers/lets_encrypt_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class LetsEncryptControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Added a configurable endpoint for LetsEncrypt at `/.well-known/acme-challenge/:id`. This allows retrieval of SSL certificates for the app.