### PR TITLE
Correctly display inherited dormitory preference in signup summary

### DIFF
--- a/app/assets/javascripts/register.js
+++ b/app/assets/javascripts/register.js
@@ -122,6 +122,7 @@ function orchestaCodeValid(data){
     var target = document.getElementById('valid_orchestra_code');
     target.disabled = false;
     target.checked = true;
+    $('#orchestra-name').text(data['name']);
     $('#code-invalid').hide();
     $('#code-valid').show();
     target.disabled = true;

--- a/app/assets/javascripts/register.js
+++ b/app/assets/javascripts/register.js
@@ -2,6 +2,7 @@
  * Created by Jacob on 2017-01-28.
  */
 
+var orchestraHasDormitory = false;
 
 $(document).on('turbolinks:load', function () {
     if ($('#festival_ticket').length > 0) {
@@ -117,13 +118,16 @@ function addTshirt() {
     updateArticleList();
 }
 
-function orchestaCodeValid(){
+function orchestaCodeValid(data){
     var target = document.getElementById('valid_orchestra_code');
     target.disabled = false;
     target.checked = true;
     $('#code-invalid').hide();
     $('#code-valid').show();
     target.disabled = true;
+
+    orchestraHasDormitory = data['dormitory'];
+    updateArticleList();
 }
 
 function orchestraCodeInvalid() {
@@ -134,6 +138,9 @@ function orchestraCodeInvalid() {
     $('#code-invalid').show();
     $('#code-valid').hide();
     target.disabled = true;
+
+    orchestraHasDormitory = false;
+    updateArticleList();
 }
 
 function toggleMultipleOrchestras(e) {
@@ -172,7 +179,7 @@ function updateArticleList() {
     costTotal += appendArticle(t()['orchestra']['register']['festival_ticket'], festivalTicketPrices[festivalTicketType]);
     costTotal += appendLinTekDiscount(festivalTicketType);
     costTotal += appendArticle(t()['orchestra']['register']['food_ticket'], foodTicketPrices[$('#food_ticket').val()]);
-    costTotal += appendArticle(t()['orchestra']['register']['dormitory'], dormitoryPrices[$('#sleep_over').val()]);
+    costTotal += appendArticle(t()['orchestra']['register']['dormitory'], dormitoryPrice($('#sleep_over').val()));
     costTotal += appendArticles(t()['orchestra']['register']['tshirt'], tshirtPrice, $('#collection-of-tshirts').find('li').length);
     costTotal += appendArticles(t()['orchestra']['register']['medal'], medalPrice, $('#select-medals').val());
     costTotal += appendArticles(t()['orchestra']['register']['tag'], tagPrice, $('#select-tag').val());
@@ -221,4 +228,12 @@ function appendLinTekDiscount(ticketType) {
 
 function isLinTekMember() {
     return $('#is-lintek-member').val() == 'true';
+}
+
+function dormitoryPrice(chosenIndex) {
+    if (chosenIndex == 0 && !orchestraHasDormitory) {
+        return 0;
+    }
+
+    return dormitoryPrices[chosenIndex];
 }

--- a/app/controllers/orchestra_controller.rb
+++ b/app/controllers/orchestra_controller.rb
@@ -187,7 +187,7 @@ class OrchestraController < NavigationController
 
     response = database.verify_orchestra_code params[:code]
     if response.success?
-      head :no_content
+      render :json => response
     else
       raise 'No match'
     end

--- a/app/views/orchestra/register.html.erb
+++ b/app/views/orchestra/register.html.erb
@@ -36,6 +36,7 @@
                 </span>
                 <span id="code-valid" style="display: none;">
                   <%= t('orchestra.register.code_valid') %>
+                  <span id="orchestra-name"></span>
                 </span>
               </label>
           </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,7 +53,7 @@ en:
       header: Register for an orchestra
       code: Orchestra signup code
       code_invalid: Outdated or invalid signup code, contact your orchestra leader
-      code_valid: Your code is valid
+      code_valid: Your code is valid and belongs to
       festival_ticket: Festival ticket
       festival_tickets:
         thursday:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -32,7 +32,7 @@ sv:
       header: Registrera till en orkester
       code: Orkesterkod
       code_invalid: Utdaterad eller ogiltig orkesterkod, kontakta din orkesterledare
-      code_valid: Din kod är giltig
+      code_valid: Din kod är giltig och tillhör
       festival_ticket: Festivalbiljett
       festival_tickets:
         thursday:


### PR DESCRIPTION
No longer defaults to always displaying dormitory in summary, regardless of the orchestra preference. Also enhances the code verifying process by displaying the name of the found orchestra. Must be tested with [sof-dbapp#18](https://github.com/studentorkesterfestivalen/sof-dbapp/pull/18).