### PR TITLE
Correct input label position and fix wave effect on page load

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -28,3 +28,7 @@ if (location.hash == '#register-card') {
 window.t = function() {
     return window.I18n[$('#locale').val()];
 };
+
+$(document).on('turbolinks:load', function () {
+    Materialize.updateTextFields();
+});

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -31,4 +31,5 @@ window.t = function() {
 
 $(document).on('turbolinks:load', function () {
     Materialize.updateTextFields();
+    Waves.displayEffect();
 });

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -29,6 +29,7 @@ window.t = function() {
     return window.I18n[$('#locale').val()];
 };
 
+// Fix broken input-field animation and wave effect when using turbolinks
 $(document).on('turbolinks:load', function () {
     Materialize.updateTextFields();
     Waves.displayEffect();


### PR DESCRIPTION
Materialize input-field labels where previously positioned on top of entered text when loading a page with prefilled input fields. This pull request fixes that issue.