### PR TITLE
Redirect to root on bad user management requests

### DIFF
--- a/app/controllers/user_management_controller.rb
+++ b/app/controllers/user_management_controller.rb
@@ -4,7 +4,7 @@ class UserManagementController < NavigationController
 
     @users = database.all_users
     unless @users.success?
-      render status: 403
+      redirect_to '/'
     end
   end
 
@@ -13,7 +13,7 @@ class UserManagementController < NavigationController
 
     @user = database.single_user params[:id]
     unless @user.success?
-      render status: 404
+      redirect_to '/'
     end
   end
 


### PR DESCRIPTION
Previously the server would error out (500) when a user lacking permissions tried to access the user management pages. This prevents this from happening by redirecting the user back to root.