### PR TITLE
Ensure present real name by asking students who's Kobra lookup failed

### DIFF
--- a/app/assets/stylesheets/templates.scss
+++ b/app/assets/stylesheets/templates.scss
@@ -44,6 +44,16 @@ main {
   margin-top: 40px;
 }
 
+.m-margin-top-40 {
+  margin-top: 40px;
+}
+
+@media only screen and (max-width: 601px) {
+  .m-margin-top-40 {
+    margin-top: 0;
+  }
+}
+
 .margin-bottom-40 {
   margin-bottom: 40px;
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   include AuthenticationConcern
+  include DisplayNameConcern
   include InternationalizationConcern
   protect_from_forgery with: :exception
 end

--- a/app/controllers/concerns/display_name_concern.rb
+++ b/app/controllers/concerns/display_name_concern.rb
@@ -10,13 +10,21 @@ module DisplayNameConcern
 
   def ensure_user_has_display_name
     unless current_user.nil?
-      if current_user['display_name'].nil? and not is_nag_path?
+      if has_display_name? and is_nag_path?
+        redirect_to root_url
+      end
+
+      if not has_display_name? and not is_nag_path?
         redirect_to controller: NAG_CONTROLLER, action: NAG_ACTION
       end
     end
   end
 
   private
+
+  def has_display_name?
+    not current_user['display_name'].nil?
+  end
 
   def is_nag_path?
     controller_name == NAG_CONTROLLER and action_name == NAG_ACTION

--- a/app/controllers/concerns/display_name_concern.rb
+++ b/app/controllers/concerns/display_name_concern.rb
@@ -4,11 +4,16 @@ module DisplayNameConcern
   NAG_CONTROLLER = 'user'
   NAG_ACTION = 'nag_display_name'
 
+  LOGOUT_CONTROLLER = 'user'
+  LOGOUT_ACTION = 'logout'
+
   included do
     before_action :ensure_user_has_display_name
   end
 
   def ensure_user_has_display_name
+    return if is_logout_path?
+
     unless current_user.nil?
       if has_display_name? and is_nag_path?
         redirect_to root_url
@@ -28,6 +33,10 @@ module DisplayNameConcern
 
   def is_nag_path?
     controller_name == NAG_CONTROLLER and action_name == NAG_ACTION
+  end
+
+  def is_logout_path?
+    controller_name == LOGOUT_CONTROLLER and action_name == LOGOUT_ACTION
   end
 
 end

--- a/app/controllers/concerns/display_name_concern.rb
+++ b/app/controllers/concerns/display_name_concern.rb
@@ -1,0 +1,25 @@
+module DisplayNameConcern
+  extend ActiveSupport::Concern
+
+  NAG_CONTROLLER = 'user'
+  NAG_ACTION = 'nag_display_name'
+
+  included do
+    before_action :ensure_user_has_display_name
+  end
+
+  def ensure_user_has_display_name
+    unless current_user.nil?
+      if current_user['display_name'].nil? and not is_nag_path?
+        redirect_to controller: NAG_CONTROLLER, action: NAG_ACTION
+      end
+    end
+  end
+
+  private
+
+  def is_nag_path?
+    controller_name == NAG_CONTROLLER and action_name == NAG_ACTION
+  end
+
+end

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -89,7 +89,15 @@ class UserController < NavigationController
   end
 
   def nag_display_name
-
+    if request.post?
+      response = database.update_user(current_user['id'], {user: {display_name: params[:new_name]}})
+      if response.success?
+        flash[:success] = 'Namn uppdaterat'
+        redirect_to root_url
+      else
+        flash.now[:error] = 'Kunde inte uppdatera namn'
+      end
+    end
   end
 
   def logout

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -88,6 +88,10 @@ class UserController < NavigationController
     end
   end
 
+  def nag_display_name
+
+  end
+
   def logout
     database.logout
     delete_token

--- a/app/views/user/nag_display_name.html.erb
+++ b/app/views/user/nag_display_name.html.erb
@@ -6,17 +6,20 @@
   <div class="row">
     <div class="col m8 offset-m2 s12 m-margin-top-40">
       <p>
-        Vi kunde inte hämta ditt riktiga namn från Kårservice. Vad heter du? :)
+        <b>Ojdå!</b>
       </p>
       <p>
-        Notera att du måste fylla i detta innan du kan fortsätta utforska sidan!
+        Vi kunde inte hämta ditt riktiga namn från Kårservice. Vad heter du?
+      </p>
+      <p>
+        Notera att du måste fylla i detta innan du kan fortsätta utforska sidan.
       </p>
       <form method="post">
         <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
 
         <div class="input-field">
           <input type="text" name="new_name" id="new_name">
-          <label for="new_name">Namn</label>
+          <label for="new_name">För- och efternamn</label>
         </div>
 
         <button type="submit" class="btn waves-effect waves-light">Uppdatera namn</button>

--- a/app/views/user/nag_display_name.html.erb
+++ b/app/views/user/nag_display_name.html.erb
@@ -4,19 +4,23 @@
 
 <div class="container">
   <div class="row">
-    <div class="col m8 offset-m2 s12">
+    <div class="col m8 offset-m2 s12 m-margin-top-40">
       <p>
-        Vi kunde inte hämta ditt riktiga namn från Kårservice. Vad heter du?
+        Vi kunde inte hämta ditt riktiga namn från Kårservice. Vad heter du? :)
+      </p>
+      <p>
+        Notera att du måste fylla i detta innan du kan fortsätta utforska sidan!
       </p>
       <form method="post">
         <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
 
         <div class="input-field">
-          <input type="email" name="email" id="email">
-          <label for="email">E-mail</label>
+          <input type="text" name="new_name" id="new_name">
+          <label for="new_name">Namn</label>
         </div>
 
-        <button type="submit" class="btn waves-effect waves-light">Återställ</button>
+        <button type="submit" class="btn waves-effect waves-light">Uppdatera namn</button>
+        <a href="#" class="btn red waves-effect waves-light">Logga ut</a>
       </form>
     </div>
   </div>

--- a/app/views/user/nag_display_name.html.erb
+++ b/app/views/user/nag_display_name.html.erb
@@ -23,7 +23,7 @@
         </div>
 
         <button type="submit" class="btn waves-effect waves-light">Uppdatera namn</button>
-        <a href="#" class="btn red waves-effect waves-light">Logga ut</a>
+        <a href="<%= logout_url %>" class="btn red waves-effect waves-light">Logga ut</a>
       </form>
     </div>
   </div>

--- a/app/views/user/nag_display_name.html.erb
+++ b/app/views/user/nag_display_name.html.erb
@@ -1,0 +1,23 @@
+<% content_for :header_title do %>
+    Färdigställ din profil
+<% end %>
+
+<div class="container">
+  <div class="row">
+    <div class="col m8 offset-m2 s12">
+      <p>
+        Vi kunde inte hämta ditt riktiga namn från Kårservice. Vad heter du?
+      </p>
+      <form method="post">
+        <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
+
+        <div class="input-field">
+          <input type="email" name="email" id="email">
+          <label for="email">E-mail</label>
+        </div>
+
+        <button type="submit" class="btn waves-effect waves-light">Återställ</button>
+      </form>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
   get '/logout', to: 'user#logout'
   get '/login/liu_id', to: 'user#login_liu_id'
   get '/login/verify', to: 'user#verify_liu_id'
-  get '/complete_profile', to: 'user#nag_display_name'
+  match '/complete_profile', to: 'user#nag_display_name', via: [:get, :post]
 
 
   # Orchestra

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
   get '/logout', to: 'user#logout'
   get '/login/liu_id', to: 'user#login_liu_id'
   get '/login/verify', to: 'user#verify_liu_id'
+  get '/complete_profile', to: 'user#nag_display_name'
 
 
   # Orchestra


### PR DESCRIPTION
LiU-students will have their names asked for if the lookup in Kobra fails for any reason. While they have a missing name they will not be able to explore the page until they log out. Fixes #114.